### PR TITLE
handle invalid input (fix #22)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -22,14 +22,18 @@ check_impulse_response_directory() {
 }
 
 read_choice() {
-    CHOICE=""
-    while [[ ! $CHOICE =~ ^[1-5]+$ ]]; do
+    while :; do
         read -r CHOICE
-        if [ "$CHOICE" -lt 1 ] || [ "$CHOICE" -gt 5 ]; then
-            echo "Invalid option! Please input a value between 1 and 5!"
+        if [ -z "$CHOICE" ]; then
+            CHOICE=1 #default
         fi
+        if [[ $CHOICE =~ ^[1-5]+$ ]]; then
+            break
+        fi
+        echo "Invalid option! Please input a value between 1 and 5!"
     done
 }
+
 
 install_menu(){
     echo "Please select an option for presets installation (Default=1)"


### PR DESCRIPTION
read_choice() only handles wrong input numbers correct
it **should** set the default value of 1 if nothing was entered
it should also print an error if a wrong number (or no number at all) was typed
this commit also fixes #22, as this error was also caused by handling input wrong