### PR TITLE
add metainfo file for presets

### DIFF
--- a/io.github.wwmm.easyeffects.Presets.JackHack96.metainfo.xml
+++ b/io.github.wwmm.easyeffects.Presets.JackHack96.metainfo.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>io.github.wwmm.easyeffects.Presets.JackHack96</id>
+  <extends>com.github.wwmm.easyeffects</extends>
+  <name>JackHack96 Easy Effects Presets</name>
+  <developer id="io.github.jackhack96">
+    <name>JackHack96</name>
+  </developer>
+  <summary>A varied collection of presets to configure Easy Effects</summary>
+  <url type="homepage">https://github.com/JackHack96/EasyEffects-Presets</url>
+  <url type="vcs-browser">https://github.com/JackHack96/EasyEffects-Presets</url>
+  <url type="help">https://github.com/JackHack96/EasyEffects-Presets</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+</component>


### PR DESCRIPTION
As part of implementing support for community preset packages in easyeffects itself, it would be nice to have preset repos like this one already exist as packages. @JackHack96 would you be ok with me submitting a preset package for this repo to flathub when everything is ready? You can be given commit access to the repo that will be created. There are some work in progress docs here https://github.com/wwmm/easyeffects/blob/master/COMMUNITY_PRESETS_GUIDELINES.md.

This specific file could be stored downstream in a future flathub repo, but isn't really ideal as metainfo is not flatpak/flathub specific. Feel free to add more information to the file it so long as it passes:
```
appstreamcli validate io.github.wwmm.easyeffects.JackHack96.metainfo.xml
```