### PR TITLE
rename kernel-path to kernel-name

### DIFF
--- a/Bass Boosted.json
+++ b/Bass Boosted.json
@@ -14,7 +14,7 @@
         "convolver": {
             "input-gain": -2.0,
             "ir-width": 100,
-            "kernel-path": "Razor Surround ((48k Z-Edition)) 2.Stereo +20 bass",
+            "kernel-name": "Razor Surround ((48k Z-Edition)) 2.Stereo +20 bass",
             "output-gain": 0.0
         },
         "crossfeed": {

--- a/Bass Enhancing + Perfect EQ.json
+++ b/Bass Enhancing + Perfect EQ.json
@@ -4,7 +4,7 @@
         "convolver": {
             "input-gain": -2.0,
             "ir-width": 100,
-            "kernel-path": "Razor Surround ((48k Z-Edition)) 2.Stereo +20 bass",
+            "kernel-name": "Razor Surround ((48k Z-Edition)) 2.Stereo +20 bass",
             "output-gain": 0.0
         },
         "equalizer": {


### PR DESCRIPTION
The legacy kernel path always lists a path, kernel name only the name.